### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Geodesi
+version: 3.0
+organization: Geodesi
+product: 
+repo_types: [InternalClient]
+platforms: [OS_VM]

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,5 +1,5 @@
 version: 3.0
 organization: Geodesi
 product: 
-repo_types: [InternalClient]
+repo_types: [Tool]
 platforms: [OS_VM]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,9 +4,9 @@ kind: "Component"
 metadata:
   name: "where"
   tags:
-  - "internal"
+  - "private"
 spec:
-  type: "website"
+  type: "service"
   lifecycle: "production"
   owner: "global_geodesi"
 ---

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "where"
+  tags:
+  - "internal"
+spec:
+  type: "website"
+  lifecycle: "production"
+  owner: "global_geodesi"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_where"
+  title: "Security Champion where"
+spec:
+  type: "security_champion"
+  parent: "geodesi_security_champions"
+  members:
+  - "annsilje"
+  children:
+  - "resource:where"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "where"
+  links:
+  - url: "https://github.com/kartverket/where"
+    title: "where på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_where"
+  dependencyOf:
+  - "component:where"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Geodesi`
- `product: `
- `repo_types: [InternalClient]`
- `platforms: [OS_VM]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.